### PR TITLE
Change DropdownItem text property to public

### DIFF
--- a/dropdown.v
+++ b/dropdown.v
@@ -44,6 +44,7 @@ pub struct DropdownConfig {
 }
 
 pub struct DropdownItem {
+pub:
 	text string
 }
 


### PR DESCRIPTION
`cannot refer to unexported field `text` (type `ui.DropdownItem`)`

```v
fn dropdown_method_changed(app mut App, dd &ui.Dropdown) {
	item := dd.items[dd.selected_index]
	app.method = item.text
}
```